### PR TITLE
Feature/unauth routes

### DIFF
--- a/qa-open-login.php
+++ b/qa-open-login.php
@@ -46,6 +46,13 @@ class qa_open_login
 		$action = null;
 		$key = null;
 
+		$unprotectedRoutes = explode( ",", qa_opt("open_login_unprotected_routes"));
+
+		// Don't run auth for unprotected routes
+		if (in_array($_SERVER["REQUEST_URI"], $unprotectedRoutes)) {
+			return false;
+		}
+		
 		if (!empty($_GET['hauth_start'])) {
 			$key = trim(strip_tags($_GET['hauth_start']));
 			$action = 'process';

--- a/qa-open-page-logins.php
+++ b/qa-open-page-logins.php
@@ -793,6 +793,8 @@ class qa_open_logins_page
 			);
 
 			// also save the other configurations
+			qa_opt("open_login_unprotected_routes", qa_post_text("open_login_unprotected_routes"));
+
 			$hidecss = qa_post_text('open_login_css');
 			qa_opt('open_login_css', empty($hidecss) ? 0 : 1);
 
@@ -801,7 +803,6 @@ class qa_open_logins_page
 
 			$nologin = qa_post_text('open_login_hideform');
 			qa_opt('open_login_hideform', empty($nologin) ? 0 : 1);
-
 			$remember = qa_post_text('open_login_remember');
 			qa_opt('open_login_remember', empty($remember) ? 0 : 1);
 			$saved = true;
@@ -811,6 +812,12 @@ class qa_open_logins_page
 			'ok' => $saved ? 'Open Login preferences saved' : null,
 
 			'fields' => array(
+				array(
+					'label' => 'Unprotected Routes (comma separated list):',
+					'value' => qa_html(qa_opt('open_login_unprotected_routes')),
+					'tags' => "NAME=\"open_login_unprotected_routes\"",
+				),
+
 				array(
 					'type' => 'checkbox',
 					'label' => 'Don\'t inline CSS. I included the styles in my theme\'s CSS file',


### PR DESCRIPTION
Now that we always redirect to Auth0 we need to expose a `/health` route and also add the ability to ignore `unprotected routes` for the plugin to ignore routes like `/health` or similar.